### PR TITLE
不必要なファイルの生成を避ける設定

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.6-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.6)
@@ -221,6 +223,7 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,17 @@ module SampleApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    config.generators do |g|
+      g.assets false
+      g.helper false
+      g.test_framework :rspec, 
+                           fixture: false,
+                           view_specs: false,
+                           helper_specs: false,
+                           routing_specs: false,
+                           controller_specs: false,
+                           request_specs: false
+    end
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ module SampleApp
                            routing_specs: false,
                            controller_specs: false,
                            request_specs: false
+                           
     end
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,8 +20,7 @@ module SampleApp
                            helper_specs: false,
                            routing_specs: false,
                            controller_specs: false,
-                           request_specs: false
-                           
+                           request_specs: false           
     end
     # Configuration for the application, engines, and railties goes here.
     #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+
 services:
   db:
     image: postgres


### PR DESCRIPTION
# 概要
rails generateコマンドで不要なファイルを生成しない様にしました

# 再現手順
rails generateコマンドで実行
生成ファイル上に各種アセット、ヘルパー、RSpecテストファイルがないことが確認できます

# 期待する動作
上記ファイルが生成されない

# 動作環境
-